### PR TITLE
Link libraries after -o and the object list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -Wall -Wextra -Wno-unused-parameter -ggdb
 LDFLAGS = -lm -ljack
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) -o $(TARGET) $(OBJS)
+	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS) $(LDFLAGS)
 
 all: $(TARGET)
 

--- a/Makefile.testcvm
+++ b/Makefile.testcvm
@@ -4,7 +4,7 @@ CFLAGS = -DCRUSTY_TEST -Wall -Wextra -D_FILE_OFFSET_BITS=64 -ggdb
 LDFLAGS = -lm
 
 $(TARGET): $(OBJS)
-	$(CC) $(LDFLAGS) -o $(TARGET) $(OBJS)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS)
 
 all: $(TARGET)
 


### PR DESCRIPTION
This fixes linking order on various systems, including Ubuntu.

Signed-off-by: Kevin Morris <kevr.gtalk@gmail.com>